### PR TITLE
Fix(pages): Correct layouts and add hero banner to home and blog pages

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -13,6 +13,8 @@
 
 {% include _navigation.html %}
 
+{% include page__hero.html %}
+
 {% include _google_analytics.html %}
 
 {% if page.image.feature %}

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -13,6 +13,8 @@
 
 {% include _navigation.html %}
 
+{% include page__hero.html %}
+
 {% include _google_analytics.html %}
 
 {% if page.image.feature %}

--- a/posts/index.md
+++ b/posts/index.md
@@ -1,5 +1,5 @@
 ---
-layout: single
+layout: post-index
 title: Blog
 header:
   overlay_image: /images/projects.png


### PR DESCRIPTION
This commit fixes two issues:
1. The hero banner was not appearing on the home page or the blog page.
2. The blog page was not listing the posts.

The `home` and `post-index` layouts were missing the include for the hero banner partial. This has been added to both layouts.

The blog page (`posts/index.md`) was using the `single` layout instead of the `post-index` layout, which is designed to list all the posts. The layout has been corrected.

With these changes, the home page banner, blog page banner, and the list of blog posts should now appear correctly.